### PR TITLE
Replace tilde on document uid

### DIFF
--- a/rd/rubens-guimaraes.yml
+++ b/rd/rubens-guimaraes.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Profile
-uid: rd.rubens-guimarães
+uid: rd.rubens-guimaraes
 name: Rubens Guimarães
 metadata:
   title: Rubens Guimarães - CTO


### PR DESCRIPTION
DocFx.XrefService autocomplete function can't support documents with non-ascii `uid`, using `a` instead of `ã` can make this document referenceable by other OPS documents.