### PR TITLE
add sessionize link

### DIFF
--- a/rd/tobias-fenster.yml
+++ b/rd/tobias-fenster.yml
@@ -24,6 +24,8 @@ connect:
     url: https://linkedin.com/in/tobiasfenster
   - title: Sessionize
     url: https://sessionize.com/tobiasfenster
+  - title: GitHub
+    url: https://github.com/tfenster
 location:
   display: Ulm, Germany
   lat: 48.3875039

--- a/rd/tobias-fenster.yml
+++ b/rd/tobias-fenster.yml
@@ -22,6 +22,8 @@ connect:
     url: https://twitter.com/tobiasfenster
   - title: LinkedIn
     url: https://linkedin.com/in/tobiasfenster
+  - title: Sessionize
+    url: https://sessionize.com/tobiasfenster
 location:
   display: Ulm, Germany
   lat: 48.3875039


### PR DESCRIPTION
Sessionize requires a link to the sessionize profile on this page so that it can verify the RD status